### PR TITLE
Remove Post Install Script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2190,7 +2190,6 @@
           "requires": {
             "json-stringify-safe": "^5.0.1",
             "minimist": "^1.2.0",
-            "split2": "^3.1.0",
             "through2": "^3.0.0"
           }
         },
@@ -4742,7 +4741,8 @@
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "optional": true
     },
     "content-disposition": {
       "version": "0.5.3",
@@ -8353,7 +8353,6 @@
           "requires": {
             "json-stringify-safe": "^5.0.1",
             "minimist": "^1.2.0",
-            "split2": "^3.1.0",
             "through2": "^3.0.0"
           }
         },

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "deploy-dao-dutchx": "node ./scripts/deployDao.js dutchx-params.json",
     "deploy-dao-migration": "node ./scripts/deployDao.js migration-params.json",
     "deploy-dao-nectardao": "node ./scripts/deployDao.js nectardao-params.json",
-    "deploy-dao-testdao": "node ./scripts/deployDao.js testdao-params.json",
-    "postinstall": "cd node_modules/@daostack/subgraph-experimental && rm -rf node_modules && npm install"
+    "deploy-dao-testdao": "node ./scripts/deployDao.js testdao-params.json"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/test-env-experimental",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Testing environment for DAOstack projects.",
   "main": "index.js",
   "scripts": {

--- a/release.sh
+++ b/release.sh
@@ -105,14 +105,15 @@ if [[ $devmode != 1 ]]; then
   docker push $image_name:$image_version
 
   docker-compose down -v
+
+  # pacakge on npm
+  npm publish --access public
+
   # tag on github
   echo "create tag ${image_version}"
   git tag -a $image_version -m "Release of version $image_name:$image_version"
   git push --tags
   # done
-
-  # pacakge on npm
-  npm publish --access public
 
   echo "Done!"
 fi


### PR DESCRIPTION
Hey @ben-kaufman, could you release this as well? The 4.0.0 npm package that's publishes causes installation within the client to fail due to the postinstall script. Apologies for not catching this before.